### PR TITLE
Add Robot.logInitialize() and Robot.logEnd() to every Command

### DIFF
--- a/src/main/java/org/frc2881/Robot.java
+++ b/src/main/java/org/frc2881/Robot.java
@@ -10,8 +10,8 @@
 
 package org.frc2881;
 
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.frc2881.commands.scoring.AutonomousCommand;
 import org.frc2881.subsystems.Arm;
@@ -24,9 +24,10 @@ import org.frc2881.subsystems.PrettyLights;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
-import edu.wpi.first.wpilibj.command.Subsystem;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -126,12 +127,29 @@ public class Robot extends TimedRobot {
     }
 
     private void printRobotMode(String message, String lineChar) {
-        String line = IntStream.range(0, 40 - message.length()).mapToObj(n -> lineChar).collect(Collectors.joining());
+        String line = IntStream.range(0, 40 - message.length()).mapToObj(n -> lineChar).collect(joining());
         System.err.println(message + line);
     }
 
     public static void log(String message) {
         long time = System.currentTimeMillis() - startTime;
         System.out.printf("[%6.2f] %s%n", time / 1000.0, message);
+    }
+
+    public static void logInitialize(Command command) {
+        log("Command " + command.getClass().getSimpleName() + " started");
+    }
+
+    public static void logInitialize(Command command, Object... settings) {
+        log("Command " + command.getClass().getSimpleName() + " started: " +
+                Stream.of(settings).map(Object::toString).collect(joining(", ")));
+    }
+
+    public static void logEnd(Command command) {
+        log("Command " + command.getClass().getSimpleName() + " ended");
+    }
+
+    public static void logInterrupted(Command command) {
+        log("Command " + command.getClass().getSimpleName() + " interrupted");
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/CameraSwitch.java
+++ b/src/main/java/org/frc2881/commands/basic/CameraSwitch.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.basic;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class CameraSwitch extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class CameraSwitch extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/background/NavXReset.java
+++ b/src/main/java/org/frc2881/commands/basic/background/NavXReset.java
@@ -10,41 +10,22 @@
 
 package org.frc2881.commands.basic.background;
 
-import edu.wpi.first.wpilibj.command.Command;
+import org.frc2881.Robot;
+import org.frc2881.commands.basic.wait.WaitUntilNavXDetected;
 
 /**
  *
  */
-public class NavXReset extends Command {
+public class NavXReset extends WaitUntilNavXDetected {
 
-    public NavXReset() {
-
-    }
-
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
+        // TODO: implement this
     }
 
-    // Called repeatedly when this Command is scheduled to run
-    @Override
-    protected void execute() {
-    }
-
-    // Make this return true when this Command no longer needs to run execute()
-    @Override
-    protected boolean isFinished() {
-        return false;
-    }
-
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/background/RobotPrep.java
+++ b/src/main/java/org/frc2881/commands/basic/background/RobotPrep.java
@@ -10,41 +10,22 @@
 
 package org.frc2881.commands.basic.background;
 
-import edu.wpi.first.wpilibj.command.Command;
+import edu.wpi.first.wpilibj.command.CommandGroup;
+import org.frc2881.Robot;
 
-/**
- *
- */
-public class RobotPrep extends Command {
+public class RobotPrep extends CommandGroup {
 
     public RobotPrep() {
-
+        // TODO: implement this
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
-    // Called repeatedly when this Command is scheduled to run
-    @Override
-    protected void execute() {
-    }
-
-    // Make this return true when this Command no longer needs to run execute()
-    @Override
-    protected boolean isFinished() {
-        return false;
-    }
-
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/background/TWINKLES.java
+++ b/src/main/java/org/frc2881/commands/basic/background/TWINKLES.java
@@ -11,40 +11,31 @@
 package org.frc2881.commands.basic.background;
 
 import edu.wpi.first.wpilibj.command.Command;
+import org.frc2881.Robot;
 
-/**
- *
- */
 public class TWINKLES extends Command {
 
     public TWINKLES() {
-
+        // TODO: implement this
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
-    // Called repeatedly when this Command is scheduled to run
     @Override
     protected void execute() {
+        // TODO: implement this
     }
 
-    // Make this return true when this Command no longer needs to run execute()
     @Override
     protected boolean isFinished() {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/drive/DriveForward.java
+++ b/src/main/java/org/frc2881/commands/basic/drive/DriveForward.java
@@ -11,6 +11,7 @@
 package org.frc2881.commands.basic.drive;
 
 import edu.wpi.first.wpilibj.command.Command;
+import org.frc2881.Robot;
 
 /**
  *
@@ -18,17 +19,18 @@ import edu.wpi.first.wpilibj.command.Command;
 public class DriveForward extends Command {
 
     public DriveForward() {
-
+        // TODO: implement this
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
     @Override
     protected void execute() {
+        // TODO: implement this
     }
 
     // Make this return true when this Command no longer needs to run execute()
@@ -37,14 +39,8 @@ public class DriveForward extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/drive/DriveWithJoysticks.java
+++ b/src/main/java/org/frc2881/commands/basic/drive/DriveWithJoysticks.java
@@ -9,16 +9,14 @@ import edu.wpi.first.wpilibj.command.Command;
  *
  */
 public class DriveWithJoysticks extends Command {
+
     public DriveWithJoysticks() {
-
         requires(Robot.drive);
-
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -38,15 +36,13 @@ public class DriveWithJoysticks extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-        Robot.log("Tele-op tank drive has ended");
+        Robot.logEnd(this);
     }
 
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
     @Override
     protected void interrupted() {
+        Robot.logInterrupted(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/drive/IntakeSetAsBack.java
+++ b/src/main/java/org/frc2881/commands/basic/drive/IntakeSetAsBack.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.basic.drive;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class IntakeSetAsBack extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class IntakeSetAsBack extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/rumble/RumbleDriver.java
+++ b/src/main/java/org/frc2881/commands/basic/rumble/RumbleDriver.java
@@ -17,14 +17,14 @@ import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj.GenericHID.RumbleType;
 import edu.wpi.first.wpilibj.command.Command;
 
-/**o
+/**
  *
  */
 public class RumbleDriver extends Command {
-   // Called just before this Command runs the first time
+
    @Override
    protected void initialize() {
-       Robot.log("RumbleDriver has started");
+       Robot.logInitialize(this);
        Robot.oi.driver.setRumble(RumbleType.kRightRumble, .7);
    }
 
@@ -49,6 +49,6 @@ public class RumbleDriver extends Command {
    @Override
    protected void end() {
        Robot.oi.driver.setRumble(RumbleType.kRightRumble, 0);
-       Robot.log("RumbleDriver has finished");
+       Robot.logEnd(this);
    }
 }

--- a/src/main/java/org/frc2881/commands/basic/rumble/RumbleJoysticks.java
+++ b/src/main/java/org/frc2881/commands/basic/rumble/RumbleJoysticks.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.basic.rumble;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class RumbleJoysticks extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class RumbleJoysticks extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/rumble/RumbleNo.java
+++ b/src/main/java/org/frc2881/commands/basic/rumble/RumbleNo.java
@@ -13,6 +13,8 @@ package org.frc2881.commands.basic.rumble;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.command.TimedCommand;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -26,9 +28,9 @@ public class RumbleNo extends TimedCommand {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -42,14 +44,8 @@ public class RumbleNo extends TimedCommand {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/rumble/RumbleYes.java
+++ b/src/main/java/org/frc2881/commands/basic/rumble/RumbleYes.java
@@ -13,6 +13,8 @@ package org.frc2881.commands.basic.rumble;
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.command.TimedCommand;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -26,9 +28,9 @@ public class RumbleYes extends TimedCommand {
     
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -42,14 +44,8 @@ public class RumbleYes extends TimedCommand {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/DoNothing.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/DoNothing.java
@@ -1,15 +1,15 @@
 package org.frc2881.commands.basic.wait;
 
-import org.frc2881.Robot;
 import edu.wpi.first.wpilibj.command.InstantCommand;
+
+import org.frc2881.Robot;
 
 /**
  * Pick this command in Shuffleboard to do nothing in Autonomous mode.
  */
 public class DoNothing extends InstantCommand {
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-        Robot.log("Do Nothing has ended");
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/WaitForPressure.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/WaitForPressure.java
@@ -26,12 +26,9 @@ public class WaitForPressure extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-
-        Robot.log("Wait For Pressure has started");
-
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -45,17 +42,8 @@ public class WaitForPressure extends Command {
         return timeSinceInitialized() > 0.2 && Robot.pneumatics.hasEnoughPressure();
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-
-        Robot.log("Wait For Pressure has finished.");
-
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/WaitForever.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/WaitForever.java
@@ -23,12 +23,9 @@ public class WaitForever extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        
-        Robot.log("Wait Forever has started");
-        
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -45,12 +42,6 @@ public class WaitForever extends Command {
     // Called once after isFinished returns true
     @Override
     protected void end() {
-        Robot.log("Wait Forever has finished");
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/WaitUntilCargoDetected.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/WaitUntilCargoDetected.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.basic.wait;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class WaitUntilCargoDetected extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class WaitUntilCargoDetected extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/WaitUntilHPDetected.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/WaitUntilHPDetected.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.basic.wait;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /** 
  *
  */
@@ -21,9 +23,9 @@ public class WaitUntilHPDetected extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class WaitUntilHPDetected extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/basic/wait/WaitUntilNavXDetected.java
+++ b/src/main/java/org/frc2881/commands/basic/wait/WaitUntilNavXDetected.java
@@ -11,40 +11,26 @@
 package org.frc2881.commands.basic.wait;
 
 import edu.wpi.first.wpilibj.command.Command;
+import org.frc2881.Robot;
 
 /**
  *
  */
 public class WaitUntilNavXDetected extends Command {
 
-    public WaitUntilNavXDetected() {
-
-    }
-
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
-    // Called repeatedly when this Command is scheduled to run
-    @Override
-    protected void execute() {
-    }
-
-    // Make this return true when this Command no longer needs to run execute()
     @Override
     protected boolean isFinished() {
+        // TODO: implement this
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/AutonomousCommand.java
+++ b/src/main/java/org/frc2881/commands/scoring/AutonomousCommand.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class AutonomousCommand extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class AutonomousCommand extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/arm/ArmCalibrateEncoder.java
+++ b/src/main/java/org/frc2881/commands/scoring/arm/ArmCalibrateEncoder.java
@@ -24,10 +24,9 @@ public class ArmCalibrateEncoder extends Command {
         requires(Robot.arm);
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        Robot.log("Calibrate Arm Encoder has started");
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -54,12 +53,11 @@ public class ArmCalibrateEncoder extends Command {
         return true;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
         Robot.arm.setArmMotorSpeed(0);
         Robot.arm.resetArmEncoder();
+        Robot.logEnd(this);
     }
-
 }
 

--- a/src/main/java/org/frc2881/commands/scoring/arm/ArmControl.java
+++ b/src/main/java/org/frc2881/commands/scoring/arm/ArmControl.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.arm;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class ArmControl extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class ArmControl extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/arm/ArmToHeight.java
+++ b/src/main/java/org/frc2881/commands/scoring/arm/ArmToHeight.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.arm;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class ArmToHeight extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class ArmToHeight extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/arm/ArmWrist.java
+++ b/src/main/java/org/frc2881/commands/scoring/arm/ArmWrist.java
@@ -14,6 +14,8 @@ import org.frc2881.Robot;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,15 +23,12 @@ public class ArmWrist extends Command {
 
     public ArmWrist() {
         requires(Robot.arm);
-
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        
+        Robot.logInitialize(this);
         Robot.arm.moveWrist();
-
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -40,17 +39,11 @@ public class ArmWrist extends Command {
     // Make this return true when this Command no longer needs to run execute()
     @Override
     protected boolean isFinished() {
-        return false;
+        return true;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/cargo/CargoControlRollers.java
+++ b/src/main/java/org/frc2881/commands/scoring/cargo/CargoControlRollers.java
@@ -31,10 +31,9 @@ public class CargoControlRollers extends Command {
         requires(Robot.intake);
 }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        Robot.log("Control Rollers has started");
+        Robot.logInitialize(this);
         monitoringAmps = false;
     }
 
@@ -84,9 +83,8 @@ public class CargoControlRollers extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-        Robot.log("Cargo Control Rollers has ended");
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/cargo/CargoIntake.java
+++ b/src/main/java/org/frc2881/commands/scoring/cargo/CargoIntake.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.cargo;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class CargoIntake extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class CargoIntake extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/cargo/CargoPlace.java
+++ b/src/main/java/org/frc2881/commands/scoring/cargo/CargoPlace.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.cargo;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class CargoPlace extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class CargoPlace extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/cargo/CargoSetRollers.java
+++ b/src/main/java/org/frc2881/commands/scoring/cargo/CargoSetRollers.java
@@ -26,10 +26,9 @@ public class CargoSetRollers extends Command {
         this.speed = speed;
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        Robot.log("CargoSetRollers has started: " + speed);
+        Robot.logInitialize(this, speed);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -44,10 +43,9 @@ public class CargoSetRollers extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
         Robot.intake.stopCargoRollers();
-        Robot.log("CargoSetRollers has finished");
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPControlRollers.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPControlRollers.java
@@ -32,10 +32,9 @@ public class HPControlRollers extends Command {
         requires(Robot.intake);
 }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        Robot.log("Control Rollers has started");
+        Robot.logInitialize(this);
         monitoringAmps = false;
     }
 
@@ -98,9 +97,8 @@ public class HPControlRollers extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-        Robot.log("HP Control Rollers has ended");
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPGripper.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPGripper.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.hp;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class HPGripper extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class HPGripper extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPIntakeGround.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPIntakeGround.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.hp;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class HPIntakeGround extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class HPIntakeGround extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPIntakeHuman.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPIntakeHuman.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.hp;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class HPIntakeHuman extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class HPIntakeHuman extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPPlace.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPPlace.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.hp;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class HPPlace extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class HPPlace extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPSetRollers.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPSetRollers.java
@@ -26,10 +26,9 @@ public class HPSetRollers extends Command {
         this.speed = speed;
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-        Robot.log("HPSetRollers has started: " + speed);
+        Robot.logInitialize(this, speed);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -44,10 +43,9 @@ public class HPSetRollers extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
         Robot.intake.stopHPRollers();
-        Robot.log("HPSetRollers has finished");
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/hp/HPSuction.java
+++ b/src/main/java/org/frc2881/commands/scoring/hp/HPSuction.java
@@ -25,12 +25,10 @@ public class HPSuction extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
-
+        Robot.logInitialize(this);
         Robot.intake.suction();
-
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -44,14 +42,8 @@ public class HPSuction extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/lift/LiftControl.java
+++ b/src/main/java/org/frc2881/commands/scoring/lift/LiftControl.java
@@ -24,9 +24,9 @@ public class LiftControl extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -43,17 +43,10 @@ public class LiftControl extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
         Robot.lift.setLiftLeft(0);
         Robot.lift.setLiftRight(0);
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
-        end();
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/lift/LiftCrawler.java
+++ b/src/main/java/org/frc2881/commands/scoring/lift/LiftCrawler.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.lift;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class LiftCrawler extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class LiftCrawler extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/lift/LiftPin.java
+++ b/src/main/java/org/frc2881/commands/scoring/lift/LiftPin.java
@@ -23,9 +23,9 @@ public class LiftPin extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -40,16 +40,9 @@ public class LiftPin extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
         Robot.lift.setLiftPin(false);
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
-        end();
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/lift/LiftSetScrew.java
+++ b/src/main/java/org/frc2881/commands/scoring/lift/LiftSetScrew.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.lift;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class LiftSetScrew extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,8 @@ public class LiftSetScrew extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
-    }
-
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
+        Robot.logEnd(this);
     }
 }

--- a/src/main/java/org/frc2881/commands/scoring/lift/LiftToHeight.java
+++ b/src/main/java/org/frc2881/commands/scoring/lift/LiftToHeight.java
@@ -12,6 +12,8 @@ package org.frc2881.commands.scoring.lift;
 
 import edu.wpi.first.wpilibj.command.Command;
 
+import org.frc2881.Robot;
+
 /**
  *
  */
@@ -21,9 +23,9 @@ public class LiftToHeight extends Command {
 
     }
 
-    // Called just before this Command runs the first time
     @Override
     protected void initialize() {
+        Robot.logInitialize(this);
     }
 
     // Called repeatedly when this Command is scheduled to run
@@ -37,14 +39,9 @@ public class LiftToHeight extends Command {
         return false;
     }
 
-    // Called once after isFinished returns true
     @Override
     protected void end() {
+        Robot.logEnd(this);
     }
 
-    // Called when another command which requires one or more of the same
-    // subsystems is scheduled to run
-    @Override
-    protected void interrupted() {
-    }
 }


### PR DESCRIPTION
Delete more RobotBuilder-generated code, mainly the `interrupted()` methods.

Log command start/stop by doing the following:

Replace every empty `initialized()` method with:
```
@Override
protected void initialize() {
    Robot.logInitialize(this);
}
```

Replace every empty `end()` method with:
```
@Override
protected void end() {
    Robot.logEnd(this);
}
```
