### PR TITLE
Fix pneumatics issue by copying 2018 code, invert drive & arm

### DIFF
--- a/src/main/java/org/frc2881/subsystems/Arm.java
+++ b/src/main/java/org/frc2881/subsystems/Arm.java
@@ -52,7 +52,7 @@ public class Arm extends PIDSubsystem {
 
         armMotor = new Spark(0);
         addChild("Arm Motor",armMotor);
-        armMotor.setInverted(false);
+        armMotor.setInverted(true);
         
         armEncoder = new Encoder(6, 7, false, EncodingType.k4X);
         addChild("Arm Encoder",armEncoder);

--- a/src/main/java/org/frc2881/subsystems/Drive.java
+++ b/src/main/java/org/frc2881/subsystems/Drive.java
@@ -68,9 +68,6 @@ public class Drive extends Subsystem {
             left = addDevice("Left", new WPI_TalonSRX(1));
             right = addDevice("Right", new WPI_TalonSRX(2));
         }
-
-        // Left and right are oriented in opposite ways so one is usually inverted
-        right.setInverted(true);
         
         differentialDrive = new DifferentialDrive(left, right);
         addChild("Differential Drive",differentialDrive);

--- a/src/main/java/org/frc2881/subsystems/Pneumatics.java
+++ b/src/main/java/org/frc2881/subsystems/Pneumatics.java
@@ -47,15 +47,14 @@ public class Pneumatics extends Subsystem {
     @Override
     public void initSendable(SendableBuilder builder) {
         super.initSendable(builder);
+        builder.addBooleanProperty("ClosedLoop", compressor::getClosedLoopControl, compressor::setClosedLoopControl);
         builder.addDoubleProperty("Pressure", this::getPressure, null);
     }
 
     @Override
     public void initDefaultCommand() {
-
-        // Set the default command for a subsystem here.
-        // setDefaultCommand(new MySpecialCommand());
     }
+
     public double getPressure(){
         //http://www.revrobotics.com/content/docs/REV-11-1107-DS.pdf formula for pressure
         double vout = compressorPressure.getAverageVoltage();


### PR DESCRIPTION
We need to call `Compressor.start()` when the robot starts up to enable closed-loop mode.  Copy the "reset" code pattern from the 2018 robot to do this.

Also, invert the drive train right motors and the arm motors to get things moving in the right direction.