### PR TITLE
Upgrade NavX libraries

### DIFF
--- a/vendordeps/navx_frc.json
+++ b/vendordeps/navx_frc.json
@@ -1,7 +1,7 @@
 {
     "fileName": "navx_frc.json",
     "name": "KauaiLabs_navX_FRC",
-    "version": "3.1.344",
+    "version": "3.1.366",
     "uuid": "cb311d09-36e9-4143-a032-55bb2b94443b",
     "mavenUrls": [
         "https://repo1.maven.org/maven2/"
@@ -11,7 +11,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-java",
-            "version": "3.1.344"
+            "version": "3.1.366"
         }
     ],
     "jniDependencies": [],
@@ -19,7 +19,7 @@
         {
             "groupId": "com.kauailabs.navx.frc",
             "artifactId": "navx-cpp",
-            "version": "3.1.344",
+            "version": "3.1.366",
             "headerClassifier": "headers",
             "sourcesClassifier": "sources",
             "sharedLibrary": false,


### PR DESCRIPTION
Release notes at https://pdocs.kauailabs.com/navx-mxp/software/roborio-libraries/java/

> Update:  2/2/2019 – Version 3.1.366 is now available – which is compatible with the 2019 FRC Release (2019.1.1).
